### PR TITLE
Asset Scripts Output version correctly + Working Directory

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -4,6 +4,9 @@
 
 set -e
 
+exec 3>&1 # make stdout available as fd 3 for the result
+exec 1>&2 # redirect all output to stderr for logging
+
 # parse incoming config data
 payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
@@ -26,4 +29,4 @@ fi
 # Consider the most recent LastModified timestamp as the most recent version.
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$prefix" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
-echo "[$recent]"
+echo "[$recent]" >&3

--- a/assets/emit.sh
+++ b/assets/emit.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -e
-
-# give back a(n empty) version, so that the check passes when using `in`/`out`
-echo "{
-  \"version\": {}
-}"

--- a/assets/in
+++ b/assets/in
@@ -38,4 +38,10 @@ echo "Downloading from S3..."
 eval aws s3 sync "s3://$bucket/$path" $dest $options
 echo "...done."
 
-source "$(dirname $0)/emit.sh" >&3
+
+timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
+recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
+
+echo "{
+  \"version\": {$recent}
+}" >&3

--- a/assets/in
+++ b/assets/in
@@ -19,7 +19,6 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
-dir=$(echo "$payload" | jq -r '.source.dir // ""')
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
@@ -36,7 +35,7 @@ fi
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 echo "Downloading from S3..."
-eval aws s3 sync "s3://$bucket/$path" "$dest/$dir" $options
+eval aws s3 sync "s3://$bucket/$path" $dest $options
 echo "...done."
 
 source "$(dirname $0)/emit.sh" >&3

--- a/assets/in
+++ b/assets/in
@@ -19,6 +19,7 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+skip_download="$(jq -r '.params.skip_download // false')"
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
@@ -34,10 +35,11 @@ fi
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
-echo "Downloading from S3..."
-eval aws s3 sync "s3://$bucket/$path" $dest $options
-echo "...done."
-
+if [ "$skip_download" = "false" ]; then
+  echo "Downloading from S3..."
+  eval aws s3 sync "s3://$bucket/$path" $dest $options
+  echo "...done."
+fi
 
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"

--- a/assets/in
+++ b/assets/in
@@ -42,6 +42,6 @@ echo "...done."
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
-echo "{
+jq -n "{
   version: $(echo $recent | jq -R .) 
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -19,6 +19,7 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+dir=$(echo "$payload" | jq -r '.source.dir // ""')
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
@@ -35,7 +36,7 @@ fi
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 echo "Downloading from S3..."
-eval aws s3 sync "s3://$bucket/$path" $dest $options
+eval aws s3 sync "s3://$bucket/$path" "$dest/$dir" $options
 echo "...done."
 
 source "$(dirname $0)/emit.sh" >&3

--- a/assets/in
+++ b/assets/in
@@ -20,7 +20,7 @@ bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 skip_download="$(jq -r '.params.skip_download // false')"
-
+echo $skip_download
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
@@ -35,11 +35,9 @@ fi
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
-if [ "$skip_download" = "false" ]; then
-  echo "Downloading from S3..."
-  eval aws s3 sync "s3://$bucket/$path" $dest $options
-  echo "...done."
-fi
+echo "Downloading from S3..."
+eval aws s3 sync "s3://$bucket/$path" $dest $options
+echo "...done."
 
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"

--- a/assets/in
+++ b/assets/in
@@ -42,6 +42,6 @@ echo "...done."
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
-echo "{
+jq -n "{
   version: $recent
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -43,5 +43,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": \"$recent\" 
+  \"version\": $recent 
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -19,8 +19,8 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
-skip_download="$(jq -r '.params.skip_download // false')"
-echo $skip_download
+skip_download="$(echo "$payload" | jq -r '.params.skip_download // false')"
+
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
@@ -35,9 +35,11 @@ fi
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
-echo "Downloading from S3..."
-eval aws s3 sync "s3://$bucket/$path" $dest $options
-echo "...done."
+if [ "$skip_download" = "false" ]; then
+  echo "Downloading from S3..."
+  eval aws s3 sync "s3://$bucket/$path" $dest $options
+  echo "...done."
+fi
 
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"

--- a/assets/in
+++ b/assets/in
@@ -43,5 +43,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": {$recent}
+  \"version\": { "ref": $recent}
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -43,5 +43,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": $recent 
+  version: $(echo $recent | jq -R .) 
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -43,5 +43,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": { \"ref\": $recent }
+  \"version\": { \"ref\": \"$recent\" }
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -43,5 +43,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": { \"ref\": \"$recent\" }
+  \"version\": \"$recent\" 
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -42,6 +42,6 @@ echo "...done."
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
-jq -n "{
-  version: $(echo $recent | jq -R .) 
+echo "{
+  version: $recent
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -43,5 +43,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": { "ref": $recent}
+  \"version\": { \"ref\": $recent }
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -18,7 +18,7 @@ fi
 payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
-options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+options=$(echo "$payload" | jq -r '.params.options // [] | join(" ")')
 skip_download="$(echo "$payload" | jq -r '.params.skip_download // false')"
 
 # export for `aws` cli

--- a/assets/in
+++ b/assets/in
@@ -39,6 +39,8 @@ if [ "$skip_download" = "false" ]; then
   echo "Downloading from S3..."
   eval aws s3 sync "s3://$bucket/$path" $dest $options
   echo "...done."
+else 
+  echo "Skipping download..."
 fi
 
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 jq -n "{
-  version: $(echo $recent | jq -R .) 
+  version: $recent
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": {$recent}
+  \"version\": { "ref": $recent }
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -19,7 +19,7 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
-dir=$(echo "$payload" | jq -r '.source.dir')
+dir=$(echo "$payload" | jq -r '.source.dir // ""')
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')

--- a/assets/out
+++ b/assets/out
@@ -19,7 +19,7 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
-dir=$(echo "$payload" | jq -r '.source.dir // ""')
+dir=$(echo "$payload" | jq -r '.params.dir // "."')
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
@@ -35,8 +35,9 @@ fi
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
-echo "Uploading to S3..."
-eval aws s3 sync "$source/$dir" "s3://$bucket/$path" $options
+cd "$source/$dir"
+echo "Uploading to S3 from '$dir'..."
+eval aws s3 sync $source/$dir "s3://$bucket/$path" $options
 echo "...done."
 
 source "$(dirname $0)/emit.sh" >&3

--- a/assets/out
+++ b/assets/out
@@ -40,4 +40,9 @@ echo "Uploading to S3 from '$dir'..."
 eval aws s3 sync $source/$dir "s3://$bucket/$path" $options
 echo "...done."
 
-source "$(dirname $0)/emit.sh" >&3
+timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
+recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
+
+echo "{
+  \"version\": {$recent}
+}" >&3

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": { \"ref\": \"$recent\" }
+  \"version\": \"$recent\" 
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": $recent 
+  version: $(echo $recent | jq -R .) 
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -18,7 +18,7 @@ fi
 payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
-options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+options=$(echo "$payload" | jq -r '.params.options // [] | join(" ")')
 dir=$(echo "$payload" | jq -r '.params.dir // "."')
 
 # export for `aws` cli

--- a/assets/out
+++ b/assets/out
@@ -7,7 +7,6 @@ exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 source=$1
-ls -la
 
 if [ -z "$source" ]; then
   echo "usage: $0 </full/path/to/dir>"
@@ -20,11 +19,13 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+dir=$(echo "$payload" | jq -r '.source.dir')
 
 echo $source
 echo $bucket
 echo $path
 echo $options
+echo $dir
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
@@ -41,7 +42,7 @@ fi
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 echo "Uploading to S3..."
-eval aws s3 sync $source "s3://$bucket/$path" $options
+eval aws s3 sync "$source/$dir" "s3://$bucket/$path" $options
 echo "...done."
 
 source "$(dirname $0)/emit.sh" >&3

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": \"$recent\" 
+  \"version\": $recent 
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": { "ref": $recent }
+  \"version\": { \"ref\": $recent }
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -21,12 +21,6 @@ path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 dir=$(echo "$payload" | jq -r '.source.dir')
 
-echo $source
-echo $bucket
-echo $path
-echo $options
-echo $dir
-
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')

--- a/assets/out
+++ b/assets/out
@@ -44,5 +44,5 @@ timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'C
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
 echo "{
-  \"version\": { \"ref\": $recent }
+  \"version\": { \"ref\": \"$recent\" }
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -43,6 +43,6 @@ echo "...done."
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
 recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
 
-echo "{
+jq -n "{
   version: $(echo $recent | jq -R .) 
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -7,6 +7,7 @@ exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 source=$1
+ls -la
 
 if [ -z "$source" ]; then
   echo "usage: $0 </full/path/to/dir>"
@@ -19,6 +20,11 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+
+echo $source
+echo $bucket
+echo $path
+echo $options
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')


### PR DESCRIPTION
Prior to this, the in and out scripts would call an emit script to output an empty version.

This caused:
- Click on a resource using this resource type: No jobs are shown as inputs or outputs
- Jobs not using latest version of the s3-resource-simple