### PR TITLE
Toggle debug when interacting with sensitive values

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -14,6 +14,8 @@ if [ -z "$source" ]; then
 fi
 #######################################
 
+# disable trace since we're interacting with sensitive values
+set +x
 # parse incoming config data
 payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
@@ -31,6 +33,9 @@ if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
   export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 fi
+
+# re-enable trace since we're done interacting with sensitive values
+set -x
 
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION


### PR DESCRIPTION
With trace enabled for the whole script, during processing of the
payload, access keys and id's are printed to stdout. Trace has been
disabled where processing sensitive information and re-enabled once
processing of these values has completed.

Maybe this should be a put parameter?

## Changes proposed in this pull request:

Disabled tracing when processing sensitive information

## Security considerations

Removed output of sensitive values.
