### PR TITLE
General best-practices cleanup

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -5,25 +5,31 @@
 set -e
 
 # parse incoming config data
-payload=`cat`
-bucket=$(echo "$payload" | jq -r '.source.bucket')
-prefix="$(echo "$payload" | jq -r '.source.path // ""')"
+eval "$(jq -r '.source | [
+  "bucket=\(.bucket | @sh)",
+  "path=\(.path // "" | @sh)",
+  "AWS_ACCESS_KEY_ID=\(.access_key_id // "" | @sh)",
+  "AWS_SECRET_ACCESS_KEY=\(.secret_access_key // "" | @sh)",
+  "AWS_DEFAULT_REGION=\(.region // "" | @sh)"
+] | join("\n")')"
 
-# export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
-AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region // empty')
+# hints for static checking
+: "${bucket:=}" "${path:=}" "${AWS_ACCESS_KEY_ID:=}" "${AWS_SECRET_ACCESS_KEY:=}" "${AWS_DEFAULT_REGION:=}"
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
-  export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-  export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 fi
 
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 # Consider the most recent LastModified timestamp as the most recent version.
-timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$prefix" --query 'Contents[].{LastModified: LastModified}')
-recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
-echo "[$recent]"
+timestamps=$(aws s3api list-objects --bucket "$bucket" --prefix "$path" --query 'Contents[].{LastModified: LastModified}')
+if [ "$timestamps" != "null" ]; then
+  recent="$(printf '%s\n' "$timestamps" | jq -r 'max_by(.LastModified)')"
+else
+  recent=''
+fi
+
+printf '%s\n' "[$recent]"

--- a/assets/emit.sh
+++ b/assets/emit.sh
@@ -3,6 +3,6 @@
 set -e
 
 # give back a(n empty) version, so that the check passes when using `in`/`out`
-echo "{
-  \"version\": {}
-}"
+echo '{
+  "version": {}
+}'

--- a/assets/in
+++ b/assets/in
@@ -15,27 +15,29 @@ fi
 #######################################
 
 # parse incoming config data
-payload=`cat`
-bucket=$(echo "$payload" | jq -r '.source.bucket')
-path=$(echo "$payload" | jq -r '.source.path // ""')
-options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
+eval "$(jq -r '.source | [
+  "bucket=\(.bucket | @sh)",
+  "path=\(.path // "" | @sh)",
+  "options=\(.options // [] | join(" ") | @sh)",
+  "AWS_ACCESS_KEY_ID=\(.access_key_id // "" | @sh)",
+  "AWS_SECRET_ACCESS_KEY=\(.secret_access_key // "" | @sh)",
+  "AWS_DEFAULT_REGION=\(.region // "" | @sh)"
+] | join("\n")')"
 
-# export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
-AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region // empty')
+# hints for static checking
+: "${bucket:=}" "${path:=}" "${options:=}" "${AWS_ACCESS_KEY_ID:=}" "${AWS_SECRET_ACCESS_KEY:=}" "${AWS_DEFAULT_REGION:=}"
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
-  export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-  export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 fi
 
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 echo "Downloading from S3..."
-eval aws s3 sync "s3://$bucket/$path" $dest $options
+eval "set -- $options" # transform options list into argument vector elements
+aws s3 sync "s3://$bucket/$path" "$dest" "$@"
 echo "...done."
 
-. "$(dirname $0)/emit.sh" >&3
+. "$(dirname "$0")/emit.sh" >&3

--- a/assets/out
+++ b/assets/out
@@ -16,22 +16,23 @@ fi
 
 # disable trace since we're interacting with sensitive values
 set +x
-# parse incoming config data
-payload=`cat`
-bucket=$(echo "$payload" | jq -r '.source.bucket')
-path=$(echo "$payload" | jq -r '.source.path // ""')
-options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
-change_dir_to=$(echo "$payload" | jq -r '.source.change_dir_to // "." ')
 
-# export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
-AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region // empty')
+eval "$(jq -r '.source | [
+  "bucket=\(.bucket | @sh)",
+  "path=\(.path // "" | @sh)",
+  "change_dir_to=\(.change_dir_to // "." | @sh)",
+  "AWS_ACCESS_KEY_ID=\(.access_key_id // "" | @sh)",
+  "AWS_SECRET_ACCESS_KEY=\(.secret_access_key // "" | @sh)",
+  "AWS_DEFAULT_REGION=\(.region // "" | @sh)",
+  "options=\(.options // [] | join(" ") | @sh)"
+] | join("\n")')"
+
+# hints for static checking
+: "${bucket:=}" "${path:=}" "${change_dir_to:=}" "${options:=}" "${AWS_ACCESS_KEY_ID:=}" "${AWS_SECRET_ACCESS_KEY:=}" "${AWS_DEFAULT_REGION:=}"
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
-  export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-  export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 fi
 
 # re-enable trace since we're done interacting with sensitive values
@@ -40,10 +41,11 @@ set -x
 # Export AWS_DEFAULT_REGION if set
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
-cd ${source}/${change_dir_to}
+cd "${source}/${change_dir_to}"
 
 echo "Uploading to S3..."
-eval aws s3 sync . "s3://$bucket/$path" $options
+eval "set -- $options"
+aws s3 sync . "s3://$bucket/$path" "$@"
 echo "...done."
 
-. "$(dirname $0)/emit.sh" >&3
+. "$(dirname "$0")/emit.sh" >&3


### PR DESCRIPTION
## Changes proposed in this pull request:

- Avoid calling jq more than once per operation. To do this, we have `jq` generate assignments with eval-safe escaping setting all required shell variables from a single invocation.
- Avoid passing anything but options through eval (keeping options themselves from being eval'd will be a compatibility-breaking change, and is the subject of cloud-gov/s3-resource-simple#50). The prior logic running `eval aws s3 sync "s3://$bucket/$path" $dest $options` gained none of the benefit from quotes around `s3://$bucket/$path`, because `eval` itself concatenated the literal arguments (with syntactic quotes discarded from the quote-removal parsing stage) into a single string before starting the parsing process over from the beginning; the new logic no longer uses `eval` for this entire command, but instead only uses `eval` when processing `$options` into `"$@"`.
- Avoid using `echo` to handle non-constant data (which introduces substantial portability problems across different implementations of `sh`; see https://unix.stackexchange.com/a/65819/3113 and https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html). Also avoid `echo $variable` where `$variable` is unquoted, which can result in values being glob-expanded before being passed to `echo`, as well as transforming characters in IFS to spaces and collapsing runs of multiple such characters to a single instance per each.
- Handle "null" return value from `aws s3api list-objects` gratefully (cloud-gov/s3-resource-simple#49)
- Quote `"$0"` inside `"$(dirname "$0")"`; the modern command substitution format used here introduces a new quoting context, so directory names with spaces (or an unexpected `IFS` value) could result `dirname` being passed an unexpected number of arguments with the old code.

## Security considerations

Because we deliberately do not fix cloud-gov/s3-resource-simple#50, the preexisting opportunity for shell injection via `$options` remains intact. However, we do narrow the code to _only_ be `eval`ing `$options`, so it's no longer possible to perform shell injection via `$bucket` or `$path`.

In every other respect, this PR works to reduce runtime ambiguity, and thus to also reduce attack surface.